### PR TITLE
Refine/splash screen search page

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -8,6 +8,7 @@
   "collectCoverageFrom": [
     "**/src/**",
     "!**/aws-exports.js",
+    "!**/withAuth.js",
     "!**/index.js",
     "!**/node_modules/**",
     "!**/helpers/**"

--- a/src/app.js
+++ b/src/app.js
@@ -10,11 +10,23 @@ import Navbar from './components/navbar';
 import logOut from './helpers/user-log/log-out';
 import { UserContextProvider } from './helpers/user-context/user-context';
 
+// import { Auth } from 'aws-amplify';
+
+// check which of these values stays
+// Auth.currentCredentials().then((data) => console.log(data));
+
+// Auth.currentUserCredentials().then((data) => console.log(data));
+
 const App = () => {
+    const isLoggedIn =
+        sessionStorage.isLoggedIn && JSON.parse(sessionStorage.isLoggedIn)
+            ? JSON.parse(sessionStorage.isLoggedIn)
+            : false;
+
     return (
         <UserContextProvider>
             <BrowserRouter>
-                <SplashScreen />
+                {!isLoggedIn ? <SplashScreen /> : null}
                 <Background>
                     <Navbar logOut={logOut} />
                     <Switch>

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -4,10 +4,21 @@ import App from './app';
 
 const setupTest = () => mount(<App />);
 
+const setSessionStorage = (bool) => (global.sessionStorage.isLoggedIn = JSON.stringify(bool));
+
 describe('App', () => {
-    it('should render a splash screen', () => {
+    beforeEach(() => {
+        setSessionStorage(false);
+    });
+
+    it('should render a splash screen only when user first log in', () => {
         const wrapper = setupTest();
         expect(wrapper.find('[data-qa="splash-screen"]')).toHaveLength(1);
+    });
+    it('should not render the splash screen if the user refresh the page', () => {
+        setSessionStorage(true);
+        const wrapper = setupTest();
+        expect(wrapper.find('[data-qa="splash-screen"]')).toHaveLength(0);
     });
     it('should render the the background', () => {
         const wrapper = setupTest();

--- a/src/components/splash-screen/splash-screen.js
+++ b/src/components/splash-screen/splash-screen.js
@@ -10,6 +10,7 @@ const SplashScreen = ({ duration }) => {
     useEffect(() => {
         const timer = setTimeout(() => {
             setIsRendered(false);
+            sessionStorage.setItem('isLoggedIn', true);
         }, duration);
         return () => clearTimeout(timer);
     }, []);

--- a/src/helpers/user-log/log-out.js
+++ b/src/helpers/user-log/log-out.js
@@ -3,6 +3,7 @@ import { Auth } from 'aws-amplify';
 export default async function () {
     try {
         await Auth.signOut();
+        sessionStorage.clear();
         location.reload();
     } catch (error) {
         console.log('error signing out: ', error);

--- a/src/pages/home-page/home-page.js
+++ b/src/pages/home-page/home-page.js
@@ -6,22 +6,30 @@ import { GFY_TRENTING_QS } from './constants';
 import Card from '../../components/card';
 
 const HomePage = () => {
-    const [gifs, setGifs] = useState([]);
+    const [areGifsSaved, setAreGifsSaved] = useState(false);
+    const gifsStorage = sessionStorage.gifs ? JSON.parse(sessionStorage.gifs) : [];
+    const isUserLoggedIn = sessionStorage.isLoggedIn
+        ? JSON.parse(sessionStorage.isLoggedIn)
+        : false;
 
     useEffect(() => {
-        fetch(GFY_TRENTING_QS)
-            .then((response) => response.json())
-            .then((data) => setGifs(data.gfycats))
-            .catch((err) => err);
+        !isUserLoggedIn &&
+            !areGifsSaved &&
+            fetch(GFY_TRENTING_QS)
+                .then((response) => response.json())
+                .then((data) => {
+                    sessionStorage.setItem('gifs', JSON.stringify(data.gfycats));
+                    setAreGifsSaved(true);
+                })
+                .catch((err) => err);
     }, []);
 
     return (
         <div data-qa="home-page">
             <Container dataId="home-page">
                 <CardsLayout dataId="home-page-cards-layout">
-                    {gifs.map((gif) => {
+                    {gifsStorage.map((gif) => {
                         const { gifUrl, gfyName, gfyId, title } = gif;
-
                         return (
                             <Card key={gfyId} imageUrl={gifUrl} title={title} imageAlt={gfyName} />
                         );

--- a/src/pages/search-result-page/search-result-page.js
+++ b/src/pages/search-result-page/search-result-page.js
@@ -11,17 +11,21 @@ const SearchResultPage = () => {
     const { searchValue } = useContext(UserContext);
 
     useEffect(() => {
-        // searchValue &&
         fetch(GFYCATS_SEARCH_QS + searchValue + GFY_RESULT_COUNT)
             .then((response) => response.json())
-            .then((data) => setGifs(data.gfycats))
+            .then((data) => {
+                setGifs(data.gfycats);
+                sessionStorage.setItem('lastSearch', JSON.stringify(data.gfycats));
+            })
             .catch((err) => err);
     }, [searchValue]);
+
+    const searchResult = !searchValue ? JSON.parse(sessionStorage.lastSearch) : gifs;
 
     return (
         <Container dataId="search-result-page">
             <CardsLayout dataId="search-result-cards-layout">
-                {gifs.map((gif) => {
+                {searchResult.map((gif) => {
                     const { gifUrl, gfyName, gfyId, title } = gif;
                     return <Card key={gfyId} imageUrl={gifUrl} title={title} imageAlt={gfyName} />;
                 })}

--- a/src/pages/search-result-page/search-result-page.test.js
+++ b/src/pages/search-result-page/search-result-page.test.js
@@ -15,6 +15,11 @@ global.fetch = jest.fn().mockImplementation(() =>
     })
 );
 
+// global.sessionStorage = jest.fn().mockImplementation(() => ({
+//     isLoggedIn: true,
+//     lastSearch: `[{ gifUrl: 'test', gfyName: 'test', gfyId: 'test', title: 'test' }]`,
+// }));
+
 const setupTest = () =>
     mount(
         <UserContextProvider value={{ searchValue: 'test' }}>
@@ -23,6 +28,13 @@ const setupTest = () =>
     );
 
 describe('Search result page', () => {
+    beforeEach(() => {
+        global.sessionStorage.lastSearch = JSON.stringify([
+            { gifUrl: 'test', gfyName: 'test', gfyId: 'test', title: 'test' },
+            { gifUrl: 'test', gfyName: 'test', gfyId: 'testy', title: 'test' },
+        ]);
+    });
+
     it('render the page correctly', async () => {
         let wrapper;
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,6 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { HtmlWebpackLinkTypePlugin } = require('html-webpack-link-type-plugin');
 
 module.exports = function (webpackEnv) {
-
     const jsjsxRegex = /\.(js|jsx)$/;
     const cssRegex = /\.css$/;
     const cssModuleRegex = /\.module\.css$/;
@@ -95,7 +94,7 @@ module.exports = function (webpackEnv) {
             path: path.resolve(__dirname, 'dist'),
         },
         // enables source maps
-        devtool: webpackEnv ? 'source-map' : 'inline-source-map',
+        devtool: !webpackEnv ? 'inline-source-map' : false,
         devServer: {
             // allow refreshing page on a client route path, this is because the server doesn't know about the 'client side routes'
             historyApiFallback: true,


### PR DESCRIPTION
Use of sessionStorage to persist fetched data both on the search and home page, this speed up the user experience on navigation and on-page refresh when necessary.
SessionStorage is also used to establish whether the user has just logged in.
SessionStorage is cleared on logout.
